### PR TITLE
add workflow_dispatch to all_jobs workflow

### DIFF
--- a/.github/workflows/all_jobs.yaml
+++ b/.github/workflows/all_jobs.yaml
@@ -1,6 +1,7 @@
 name: All Build
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
 


### PR DESCRIPTION
I would like to be able to run the workflow "all_jobs" manually. 
Can be useful to check that everything is in order.

@nbourdis-psee am I suppose to target "main" or "develop" ?