### PR TITLE
[Fix] Add <algorithm> for std::find

### DIFF
--- a/hal_psee_plugins/test/device_discovery_psee_plugins_gtest.cpp
+++ b/hal_psee_plugins/test/device_discovery_psee_plugins_gtest.cpp
@@ -9,6 +9,7 @@
  * See the License for the specific language governing permissions and limitations under the License.                 *
  **********************************************************************************************************************/
 
+#include <algorithm> 
 #include <iostream>
 #include <fstream>
 #include <sstream>


### PR DESCRIPTION
Fix this:

`In file included from /usr/include/gtest/gtest.h:62,
                 from /home/homalozoa/local_git/contrib/openeb/utils/cpp/gtest/lib/../include/metavision/utils/gtest/gtest_with_tmp_dir.h:16,
                 from /home/homalozoa/local_git/contrib/openeb/hal_psee_plugins/test/device_discovery_psee_plugins_gtest.cpp:17:
/home/homalozoa/local_git/contrib/openeb/hal_psee_plugins/test/device_discovery_psee_plugins_gtest.cpp: In member function ‘virtual void DeviceDiscoveryPseePlugins_GTest_offline_supported_system_id_are_not_unsupported_in_the_gtest_Test::TestBody()’:
/home/homalozoa/local_git/contrib/openeb/hal_psee_plugins/test/device_discovery_psee_plugins_gtest.cpp:96:30: error: no matching function for call to ‘find(std::vector<Metavision::SystemId>::const_iterator, std::vector<Metavision::SystemId>::const_iterator, const Metavision::SystemId&)’
   96 |         ASSERT_TRUE(std::find(offline_unsupported_system_ids.cbegin(), offline_unsupported_system_ids.cend(),
      |                     ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   97 |                               system_id) == offline_unsupported_system_ids.cend());
      |                               ~~~~~~~~~~
In file included from /usr/include/c++/12.1.0/bits/locale_facets.h:48,
                 from /usr/include/c++/12.1.0/bits/basic_ios.h:37,
                 from /usr/include/c++/12.1.0/ios:44,
                 from /usr/include/c++/12.1.0/ostream:38,
                 from /usr/include/c++/12.1.0/iostream:39,
                 from /home/homalozoa/local_git/contrib/openeb/hal_psee_plugins/test/device_discovery_psee_plugins_gtest.cpp:12:
/usr/include/c++/12.1.0/bits/streambuf_iterator.h:434:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT> >::__type std::find(istreambuf_iterator<_CharT>, istreambuf_iterator<_CharT>, const _CharT2&)’
  434 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/12.1.0/bits/streambuf_iterator.h:434:5: note:   template argument deduction/substitution failed:
/home/homalozoa/local_git/contrib/openeb/hal_psee_plugins/test/device_discovery_psee_plugins_gtest.cpp:96:30: note:   ‘__gnu_cxx::__normal_iterator<const Metavision::SystemId*, std::vector<Metavision::SystemId> >’ is not derived from ‘std::istreambuf_iterator<_CharT>’
   96 |         ASSERT_TRUE(std::find(offline_unsupported_system_ids.cbegin(), offline_unsupported_system_ids.cend(),
      |                     ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   97 |                               system_id) == offline_unsupported_system_ids.cend());`