### PR TITLE
Fix building errors & Adapt to Arch Linux

### DIFF
--- a/hal_psee_plugins/test/device_discovery_psee_plugins_gtest.cpp
+++ b/hal_psee_plugins/test/device_discovery_psee_plugins_gtest.cpp
@@ -9,6 +9,7 @@
  * See the License for the specific language governing permissions and limitations under the License.                 *
  **********************************************************************************************************************/
 
+#include <algorithm>
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/sdk/modules/base/cpp/tests/generic_header_gtest.cpp
+++ b/sdk/modules/base/cpp/tests/generic_header_gtest.cpp
@@ -9,6 +9,7 @@
  * See the License for the specific language governing permissions and limitations under the License.                 *
  **********************************************************************************************************************/
 
+#include <fstream>
 #include <sstream>
 #include <gtest/gtest.h>
 #include <iomanip>

--- a/sdk/modules/base/cpp/tests/log_gtest.cpp
+++ b/sdk/modules/base/cpp/tests/log_gtest.cpp
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <cstdlib>
+#include <fstream>
 #include <iterator>
 #include <gtest/gtest.h>
 #include <type_traits>


### PR DESCRIPTION
Hey! I saw https://github.com/prophesee-ai/openeb/commit/5fba9649c1e1e729bceb5ededc9a5416d0df660e#diff-96f65902c2d71324b2a402fdf56749e3cae82c48dd38dcd57c8e3c0d4e399e6e reverted what I've pulled before(https://github.com/prophesee-ai/openeb/commit/73c9d32f947e1ffb8048a1a9df1157e32d560a76). I consider it would be a misoperation.

Anyway, I make this PR to fix all building error in Arch Linux. The building environment of Arch Linux is below.

- GCC: 12.1.0
- Python: 3.10.5
- pybind11: 2.9.2

Also, I've tested `openeb` working with pybind 2.9. Examples in tutorials work fine. So I wonder why you emphasized pybind11 version in README, are there any tricks in pybind 2.6? Thanks.