### PR TITLE
Installation for specific python version

### DIFF
--- a/cmake/custom_functions/python3.cmake
+++ b/cmake/custom_functions/python3.cmake
@@ -130,7 +130,7 @@ if (COMPILE_PYTHON3_BINDINGS)
 
     # this variable is used to set the default version for package dependency, i.e this version
     # is always available for the current installation
-    if (UNIX AND NOT APPLE (NOT DEFINED PYTHON3_DEFAULT_VERSION))
+    if (UNIX AND NOT APPLE AND (NOT DEFINED PYTHON3_DEFAULT_VERSION))
         set (PYTHON3_DEFAULT_VERSION "3.6")
         find_program(_lsb_release_exec lsb_release)
         if (_lsb_release_exec)

--- a/cmake/custom_functions/python3.cmake
+++ b/cmake/custom_functions/python3.cmake
@@ -130,7 +130,7 @@ if (COMPILE_PYTHON3_BINDINGS)
 
     # this variable is used to set the default version for package dependency, i.e this version
     # is always available for the current installation
-    if (UNIX AND NOT APPLE)
+    if (UNIX AND NOT APPLE (NOT DEFINED PYTHON3_DEFAULT_VERSION))
         set (PYTHON3_DEFAULT_VERSION "3.6")
         find_program(_lsb_release_exec lsb_release)
         if (_lsb_release_exec)


### PR DESCRIPTION
Hi! 
I've just installed openeb to with conda environment (`python=3.8`) on my ubuntu22.04 (not officially supported).
Before having completed my installation, i got the same issue on [this](https://github.com/prophesee-ai/openeb/issues/32)
As you mentioned in the issue chat, I modified `python3.cmake` such like;

```cmake
set (PYTHON3_DEFAULT_VERSION "3.8")
        find_program(_lsb_release_exec lsb_release)
        if (_lsb_release_exec)
            execute_process(COMMAND ${_lsb_release_exec} -cs
                OUTPUT_VARIABLE _ubuntu_platform
                OUTPUT_STRIP_TRAILING_WHITESPACE
            )
            if (("${_ubuntu_platform}" STREQUAL "bionic") OR ("${_ubuntu_platform}" STREQUAL "jammy")) ## Here!!
                set (PYTHON3_DEFAULT_VERSION "3.8")
            endif ()
        endif()	
```

And then, i've just completed installation.
However, above modification is slightly dirty i think, so how about this change of my pull request?
This commit allows us to pass a specific python version in generating Makefile.

For example, when i want to install openeb to python=3.7, use the below command;

```bash
cmake .. -DPYBIND11_TEST=OFF -DPYTHON3_DEFAULT_VERSION=3.7
```

instead of

```bash
cmake .. -DPYBIND11_TEST=OFF # Force to set 3.6
```

I'm beginner for cmake, so this change may not be the best solution.
But could you check whether this pull request is OK or not?
Finally, Thank you for opening to public for such nice programs.