### PR TITLE
Add iostream include to fix missing std:cerr error

### DIFF
--- a/hal/python/bindings/metavision_hal_bindings.cpp
+++ b/hal/python/bindings/metavision_hal_bindings.cpp
@@ -15,7 +15,7 @@
 #endif
 
 #include <pybind11/pybind11.h>
-
+#include <iostream>
 #include "metavision/utils/pybind/deprecation_warning_exception.h"
 #include "hal_python_binder.h"
 #include "metavision/hal/device/device.h"


### PR DESCRIPTION
Compiling on `Manjaro 5.19.7` with `gcc version 12.2.0`, the following error occurs:

```
openeb/hal/python/bindings/metavision_hal_bindings.cpp:42:14: error: ‘cerr’ is not a member of ‘std’
   42 |         std::cerr << "Exception Raised while loading metavision_sdk_base: " << e.what() << std::endl;
```

Adding the `#include <iostream>` fixes this issue.