### PR TITLE
[Build] Relax ffmpeg version path when building on windows.

### DIFF
--- a/.github/workflows/all_jobs.yaml
+++ b/.github/workflows/all_jobs.yaml
@@ -155,7 +155,7 @@ jobs:
       - name: Build openEB
         shell: bash
         run: |
-          export PATH=$PATH:`realpath ../ffmpeg-5.0.1-full_build/bin`
+          export PATH=$PATH:`realpath ../ffmpeg-*-full_build/bin`
           mkdir build && cd build
           cmake -A x64 -DCMAKE_TOOLCHAIN_FILE="../cmake/toolchains/vcpkg.cmake" \
                 -DVCPKG_DIRECTORY=`realpath ../../vcpkg` \


### PR DESCRIPTION
Because the `Upload Windows Binaries` job fetches the lastest version of ffmpeg. The version will change every now and then.