### PR TITLE
[CI] updating windows binaries

### DIFF
--- a/.github/workflows/upload_win_binaries.yaml
+++ b/.github/workflows/upload_win_binaries.yaml
@@ -6,7 +6,7 @@ on:
     - cron: "15 2 1 */2 *"
 
 env:
-  win_binaries_download_address: "https://prophesee-bamboo.s3.eu-west-1.amazonaws.com/build-env/vcpkg-export-20220511-MV3.0.0.zip"
+  win_binaries_download_address: "https://prophesee-bamboo.s3.eu-west-1.amazonaws.com/build-env/vcpkg-export-20221025-MV3.1.0.zip"
   ffmpeg_archive_download_address: "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z"
 
 jobs:


### PR DESCRIPTION
Hello,

The VCPKG binaries for Github Actions tests have been updated and uplodaded to AWS.
This PR redirects the download of the binaries to the correct new address.
It's been tested off Metavision 3.1.0 and has succeeded in all tests.