### PR TITLE
[CI] Reduce raw_reader pytests to fit CI nodes memory requirements

### DIFF
--- a/sdk/modules/core/python/pypkg/metavision_core/event_io/raw_reader.py
+++ b/sdk/modules/core/python/pypkg/metavision_core/event_io/raw_reader.py
@@ -401,14 +401,14 @@ class RawReader(RawReaderBase):
             to be activated (only relevant for a live camera).
     """
 
-    def __init__(self, record_base, max_events=int(1e8), do_time_shifting=True,
+    def __init__(self, record_base, max_events=int(1e7), do_time_shifting=True,
                  device=None, initiate_device=True, use_external_triggers=[]):
         super().__init__(record_base, device=device, do_time_shifting=do_time_shifting,
                          initiate_device=initiate_device, use_external_triggers=use_external_triggers)
         self._event_buffer = np.empty(max_events, dtype=EventCD)
 
     @classmethod
-    def from_device(cls, device, max_events=int(1e8)):
+    def from_device(cls, device, max_events=int(1e7)):
         """
         Alternate way of constructing an RawReader from an already initialized HAL device.
 

--- a/sdk/modules/core/python/tests/raw_reader_pytest.py
+++ b/sdk/modules/core/python/tests/raw_reader_pytest.py
@@ -27,7 +27,7 @@ def pytestcase_rawreader_init(tmpdir, dataset_dir):
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
 
-    video = RawReader(filename, max_events=int(1e7), do_time_shifting=False)
+    video = RawReader(filename, do_time_shifting=False)
     # WHEN
     video.reset()
     # THEN
@@ -139,7 +139,7 @@ def pytestcase_rawreader_load_n_events_too_much(tmpdir, dataset_dir):
     """Tests loading more events than the number in the file"""
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
-    video = RawReader(filename, do_time_shifting=False, max_events=int(1e7))
+    video = RawReader(filename, do_time_shifting=False)
 
     events = video.load_n_events(667850)
     assert video.done == False
@@ -158,7 +158,7 @@ def pytestcase_rawreader_load_delta_t(tmpdir, dataset_dir):
     """Tests loading events inside a time window"""
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
-    video = RawReader(filename, do_time_shifting=False, max_events=int(1e7))
+    video = RawReader(filename, do_time_shifting=False)
     assert video.current_time == 0
     _ = video.load_n_events(1)  # we are in no time shifting mode
     events = video.load_delta_t(100)
@@ -181,7 +181,7 @@ def pytestcase_rawreader_load_small_delta_t(tmpdir, dataset_dir):
     """Tests loading events inside a time window smaller than the controller timeslice"""
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
-    video = RawReader(filename, do_time_shifting=False, max_events=int(1e7))
+    video = RawReader(filename, do_time_shifting=False)
     assert video.current_time == 0
     _ = video.load_n_events(1)  # we are in no time shifting mode
     events = video.load_delta_t(100)
@@ -240,7 +240,7 @@ def pytestcase_rawreader_load_delta_t_too_much(tmpdir, dataset_dir):
     """Tests loading events in a time window larger than total file duration"""
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
-    video = RawReader(filename, do_time_shifting=False, max_events=int(1e7))
+    video = RawReader(filename, do_time_shifting=False)
     assert video.current_time == 0
     while video.current_time < 16420000:
         _ = video.load_delta_t(10000)
@@ -266,7 +266,7 @@ def pytestcase_rawreader_seek_time(tmpdir, dataset_dir):
     """Tests loading events after a call to seek_time()"""
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
-    video = RawReader(filename, do_time_shifting=False, max_events=int(1e7))
+    video = RawReader(filename, do_time_shifting=False)
     assert video.current_time == 0
 
     video.seek_time(16420000)
@@ -292,7 +292,7 @@ def pytestcase_rawreader_exotic_seek_time_and_delta_t(tmpdir, dataset_dir):
     """Tests loading events after a call to seek_time() using a variety delta_t values"""
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
-    video = RawReader(filename, do_time_shifting=False, max_events=int(1e7))
+    video = RawReader(filename, do_time_shifting=False)
     assert video.current_time == 0
 
     video.seek_time(16420458)
@@ -319,7 +319,7 @@ def pytestcase_rawreader_exotic_mix_seek_time_load_n_and_delta_t(tmpdir, dataset
     """Tests loading events after a call to seek_time() using a variety delta_t values"""
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
-    video = RawReader(filename, do_time_shifting=False, max_events=int(1e7))
+    video = RawReader(filename, do_time_shifting=False)
     assert video.current_time == 0
 
     video.seek_time(16420000)
@@ -391,7 +391,7 @@ def pytestcase_rawreader_equivalence(tmpdir, dataset_dir):
     # GIVEN
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
-    video = RawReader(filename, do_time_shifting=False, max_events=int(1e7))
+    video = RawReader(filename, do_time_shifting=False)
     # WHEN
     dat_evs = load_events(filename.replace(".raw", "_td.dat"))
     raw_evs = video.load_n_events(1e8)
@@ -407,7 +407,7 @@ def pytestcase_rawreader_pyreader_equivalence_mixed(tmpdir, dataset_dir):
     # GIVEN
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
-    video = RawReader(filename, do_time_shifting=False, max_events=int(1e7))
+    video = RawReader(filename, do_time_shifting=False)
     # WHEN
     dat_video = EventDatReader(filename.replace(".raw", "_td.dat"))
 
@@ -430,7 +430,7 @@ def pytestcase_rawreader_ext_triggerevent(tmpdir, dataset_dir):
     # GIVEN
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
-    video = RawReader(filename, do_time_shifting=False, max_events=int(1e7))
+    video = RawReader(filename, do_time_shifting=False)
     trigger_evt_gt = np.loadtxt(os.path.join(dataset_dir,
                                              "openeb", "core", "event_io", "triggerevt.csv"), delimiter=",")
     # WHEN
@@ -452,7 +452,7 @@ def pytestcase_rawreader_time_shifting(tmpdir, dataset_dir):
     # GIVEN
     filename = os.path.join(dataset_dir,
                             "openeb", "core", "event_io", "recording.raw")
-    video = RawReader(filename, do_time_shifting=True, max_events=int(1e7))
+    video = RawReader(filename, do_time_shifting=True)
     # WHEN
     dat_evs = load_events(filename.replace(".raw", "_td.dat"))
     raw_evs = video.load_n_events(1E8)


### PR DESCRIPTION
CI is currently failing because of memory overflow when running `raw_reader` pytests on Windows : 
```
 E       numpy.core._exceptions._ArrayMemoryError: Unable to allocate 1.49 GiB for an array with shape (100000000,) and data type {'names':['x','y','p','t'], 'formats':['<u2','<u2','<i2','<i8'], 'offsets':[0,2,4,8], 'itemsize':16}

```
ie. https://github.com/prophesee-ai/openeb/actions/runs/3548289702/jobs/5959332335


This change aims at reducing the amount of events read while running the tests. This should lower the memory footprint of the tests.