### PR TITLE
fix compiler warnings about missing and out-of-order initialization

### DIFF
--- a/sdk/modules/base/cpp/include/metavision/sdk/base/events/raw_event_frame_diff.h
+++ b/sdk/modules/base/cpp/include/metavision/sdk/base/events/raw_event_frame_diff.h
@@ -32,20 +32,20 @@ struct RawEventFrameDiffConfig {
 class RawEventFrameDiff {
 public:
     /// @brief Constructor
-    RawEventFrameDiff(const unsigned height, const unsigned width) : cfg_{width, height} {
+    RawEventFrameDiff(const unsigned height, const unsigned width) : cfg_{width, height, 0} {
         diff_.reset(new std::vector<int8_t>(height * width));
         assert(diff_);
     }
 
     /// @brief Default constructor
     RawEventFrameDiff(const RawEventFrameDiffConfig &cfg, std::unique_ptr<const std::vector<int8_t>> data) :
-        cfg_(cfg), diff_(std::move(data)) {
+        diff_(std::move(data)), cfg_(cfg) {
         assert(diff_);
     }
 
     /// @brief Copy constructor
     RawEventFrameDiff(const RawEventFrameDiff &d) :
-        cfg_(d.cfg_), diff_(std::make_unique<const std::vector<int8_t>>(d.get_data())) {}
+        diff_(std::make_unique<const std::vector<int8_t>>(d.get_data())), cfg_(d.cfg_) {}
 
     const RawEventFrameDiffConfig &get_config() const {
         return cfg_;

--- a/sdk/modules/base/cpp/include/metavision/sdk/base/events/raw_event_frame_histo.h
+++ b/sdk/modules/base/cpp/include/metavision/sdk/base/events/raw_event_frame_histo.h
@@ -46,13 +46,13 @@ public:
 
     /// @brief Default constructor
     RawEventFrameHisto(const RawEventFrameHistoConfig &cfg, std::unique_ptr<const std::vector<uint8_t>> data) :
-        cfg_(cfg), histogram_(std::move(data)) {
+        histogram_(std::move(data)), cfg_(cfg) {
         assert(histogram_);
     }
 
     /// @brief Copy constructor
     RawEventFrameHisto(const RawEventFrameHisto &h) :
-        cfg_(h.cfg_), histogram_(std::make_unique<const std::vector<uint8_t>>(h.get_data())) {}
+        histogram_(std::make_unique<const std::vector<uint8_t>>(h.get_data())), cfg_(h.cfg_) {}
 
     const RawEventFrameHistoConfig &get_config() const {
         return cfg_;


### PR DESCRIPTION
When using SDK header files for the development of a ROS driver I get warning messages related to uninitialized member variables and out-of-order initialization. This PR fixes those warnings for me.
