### PR TITLE
remove compilation warning

### DIFF
--- a/sdk/modules/core/cpp/samples/metavision_filtering/metavision_filtering.cpp
+++ b/sdk/modules/core/cpp/samples/metavision_filtering/metavision_filtering.cpp
@@ -141,6 +141,8 @@ int main(int argc, char *argv[]) {
             case Metavision::UIKeyEvent::KEY_Q:
                 should_stop = true;
                 break;
+            default:
+                break;
             }
         }
     });


### PR DESCRIPTION
some cases were not handled, so add a 'default'

"warning: 115 enumeration values not handled in switch: 'KEY_UNKNOWN', 'KEY_SPACE', 'KEY_APOSTROPHE'... [-Wswitch]"