### PR TITLE
camera_stream_slicer.h: drop default constructor to add C++20 support

### DIFF
--- a/sdk/modules/stream/cpp/include/metavision/sdk/stream/camera_stream_slicer.h
+++ b/sdk/modules/stream/cpp/include/metavision/sdk/stream/camera_stream_slicer.h
@@ -29,9 +29,6 @@ using TriggerBuffer = std::vector<EventExtTrigger>;
 struct Slice {
     using ConditionStatus = EventBufferReslicerAlgorithm::ConditionStatus;
 
-    /// @brief Default constructor
-    Slice() = default;
-
     /// @brief Comparison operator
     /// @param other Slice to compare with
     /// @return True if the two slices are equal, false otherwise


### PR DESCRIPTION
C++20 removed support for aggregate initialization with an initializer list when a constructor is defined, even a `= default` one. (see https://en.cppreference.com/w/cpp/language/aggregate_initialization#Explicitly_initialized_elements)

Otherwise fails on GCC 13 with
```
sdk/modules/stream/cpp/src/camera_stream_slicer.cpp:105:53: error: cannot convert ‘<brace-enclosed initializer list>’ to ‘Metavision::Slice&&’
  105 |         const bool new_slice_added = queue_->emplace({status, t, nevents, curt_event_buffer_, curt_trigger_buffer_});
```

Could also alternatively define an explicit constructor instead of relying on a default one, I suppose.

I know the project currently sets the standard to 17. This only came up when creating a Conan package for the open-source Metavision SDK (https://github.com/valgur/conan-center-index/blob/dev/recipes/metavision-sdk/all/conanfile.py), where the ConanCenter convention is to allow any C++ standard to be used by patching the project files, if necessary, to ensure a consistent standard is used across the whole dependency graph.