### PR TITLE
Add missing <cstdint> includes in header files that caused compile errors

### DIFF
--- a/hal/cpp/include/metavision/hal/facilities/i_digital_crop.h
+++ b/hal/cpp/include/metavision/hal/facilities/i_digital_crop.h
@@ -13,6 +13,7 @@
 #define METAVISION_HAL_FACILITY_DIGITAL_CROP_H
 
 #include "metavision/hal/facilities/i_registrable_facility.h"
+#include <cstdint>
 
 namespace Metavision {
 

--- a/hal/cpp/include/metavision/hal/facilities/i_digital_event_mask.h
+++ b/hal/cpp/include/metavision/hal/facilities/i_digital_event_mask.h
@@ -14,6 +14,7 @@
 
 #include <vector>
 #include <tuple>
+#include <cstdint>
 
 #include "metavision/hal/facilities/i_registrable_facility.h"
 

--- a/hal/cpp/include/metavision/hal/facilities/i_event_rate_activity_filter_module.h
+++ b/hal/cpp/include/metavision/hal/facilities/i_event_rate_activity_filter_module.h
@@ -13,6 +13,7 @@
 #define METAVISION_HAL_I_EVENT_RATE_ACTIVITY_FILTER_MODULE_H
 
 #include <string>
+#include <cstdint>
 
 #include "metavision/hal/facilities/i_registrable_facility.h"
 

--- a/hal/cpp/include/metavision/hal/facilities/i_hw_identification.h
+++ b/hal/cpp/include/metavision/hal/facilities/i_hw_identification.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "metavision/hal/utils/device_config.h"
 #include "metavision/hal/utils/raw_file_header.h"

--- a/hal/cpp/samples/metavision_hal_evk4_sample_plugin/include/sample_digital_crop.h
+++ b/hal/cpp/samples/metavision_hal_evk4_sample_plugin/include/sample_digital_crop.h
@@ -13,6 +13,7 @@
 #define METAVISION_HAL_SAMPLE_DIGITAL_CROP_H
 
 #include <memory>
+#include <cstdint>
 
 #include <metavision/hal/facilities/i_digital_crop.h>
 

--- a/hal_psee_plugins/include/devices/common/evk2_system_control.h
+++ b/hal_psee_plugins/include/devices/common/evk2_system_control.h
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <memory>
+#include <cstdint>
 
 namespace Metavision {
 

--- a/sdk/modules/base/cpp/include/metavision/sdk/base/events/event_erc_counter.h
+++ b/sdk/modules/base/cpp/include/metavision/sdk/base/events/event_erc_counter.h
@@ -13,6 +13,7 @@
 #define METAVISION_SDK_BASE_EVENT_ERC_COUNTER_H
 
 #include <ostream>
+#include <cstdint>
 #include "metavision/sdk/base/utils/detail/struct_pack.h"
 #include "metavision/sdk/base/utils/timestamp.h"
 #include "metavision/sdk/base/events/detail/event_traits.h"

--- a/sdk/modules/base/cpp/include/metavision/sdk/base/events/raw_event_frame_histo.h
+++ b/sdk/modules/base/cpp/include/metavision/sdk/base/events/raw_event_frame_histo.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <stdexcept>
 #include <vector>
+#include <cstdint>
 
 #include "metavision/sdk/base/events/detail/event_traits.h"
 


### PR DESCRIPTION
As reported in #156, some of the headers are missing the `#include <cstdint>`, making certain versions of GCC fail. 

For example, gcc version 15.1.1 20250425

This pull request adds the missing cstdint to the problematic files.

