### PR TITLE
Add HDF5 1.14 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ if (COMPILE_PYTHON3_BINDINGS OR BUILD_TESTING)
 endif ()
 
 # OpenCV
-find_package(OpenCV COMPONENTS core highgui imgproc videoio imgcodecs calib3d objdetect REQUIRED)
+find_package(OpenCV COMPONENTS core highgui imgproc videoio imgcodecs geometry calib stereo objdetect REQUIRED)
 
 # HDF5
 if (NOT ANDROID AND NOT HDF5_DISABLED)

--- a/hal/cpp/include/metavision/hal/facilities/i_digital_crop.h
+++ b/hal/cpp/include/metavision/hal/facilities/i_digital_crop.h
@@ -13,6 +13,7 @@
 #define METAVISION_HAL_FACILITY_DIGITAL_CROP_H
 
 #include "metavision/hal/facilities/i_registrable_facility.h"
+#include <cstdint>
 
 namespace Metavision {
 

--- a/hal/cpp/include/metavision/hal/facilities/i_digital_event_mask.h
+++ b/hal/cpp/include/metavision/hal/facilities/i_digital_event_mask.h
@@ -14,6 +14,7 @@
 
 #include <vector>
 #include <tuple>
+#include <cstdint>
 
 #include "metavision/hal/facilities/i_registrable_facility.h"
 

--- a/hal/cpp/include/metavision/hal/facilities/i_event_rate_activity_filter_module.h
+++ b/hal/cpp/include/metavision/hal/facilities/i_event_rate_activity_filter_module.h
@@ -13,6 +13,7 @@
 #define METAVISION_HAL_I_EVENT_RATE_ACTIVITY_FILTER_MODULE_H
 
 #include <string>
+#include <cstdint>
 
 #include "metavision/hal/facilities/i_registrable_facility.h"
 

--- a/hal/cpp/include/metavision/hal/facilities/i_hw_identification.h
+++ b/hal/cpp/include/metavision/hal/facilities/i_hw_identification.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "metavision/hal/utils/device_config.h"
 #include "metavision/hal/utils/raw_file_header.h"

--- a/hal/cpp/samples/metavision_hal_evk4_sample_plugin/include/sample_digital_crop.h
+++ b/hal/cpp/samples/metavision_hal_evk4_sample_plugin/include/sample_digital_crop.h
@@ -13,6 +13,7 @@
 #define METAVISION_HAL_SAMPLE_DIGITAL_CROP_H
 
 #include <memory>
+#include <cstdint>
 
 #include <metavision/hal/facilities/i_digital_crop.h>
 

--- a/hal_psee_plugins/include/devices/common/evk2_system_control.h
+++ b/hal_psee_plugins/include/devices/common/evk2_system_control.h
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <memory>
+#include <cstdint>
 
 namespace Metavision {
 

--- a/sdk/modules/base/cpp/include/metavision/sdk/base/events/event_erc_counter.h
+++ b/sdk/modules/base/cpp/include/metavision/sdk/base/events/event_erc_counter.h
@@ -13,6 +13,7 @@
 #define METAVISION_SDK_BASE_EVENT_ERC_COUNTER_H
 
 #include <ostream>
+#include <cstdint>
 #include "metavision/sdk/base/utils/detail/struct_pack.h"
 #include "metavision/sdk/base/utils/timestamp.h"
 #include "metavision/sdk/base/events/detail/event_traits.h"

--- a/sdk/modules/base/cpp/include/metavision/sdk/base/events/raw_event_frame_histo.h
+++ b/sdk/modules/base/cpp/include/metavision/sdk/base/events/raw_event_frame_histo.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <stdexcept>
 #include <vector>
+#include <cstdint>
 
 #include "metavision/sdk/base/events/detail/event_traits.h"
 

--- a/sdk/modules/core/cpp/include/metavision/sdk/core/utils/mostrecent_timestamp_buffer.h
+++ b/sdk/modules/core/cpp/include/metavision/sdk/core/utils/mostrecent_timestamp_buffer.h
@@ -13,7 +13,7 @@
 #define METAVISION_SDK_CORE_MOSTRECENT_TIMESTAMP_BUFFER_H
 
 #include <opencv2/opencv.hpp>
-#if CV_MAJOR_VERSION >= 4
+#if CV_MAJOR_VERSION >= 4 && CV_MAJOR_VERSION < 5
 #include <opencv2/imgproc/types_c.h>
 #endif
 

--- a/sdk/modules/core/cpp/include/metavision/sdk/core/utils/video_writer.h
+++ b/sdk/modules/core/cpp/include/metavision/sdk/core/utils/video_writer.h
@@ -177,8 +177,11 @@ public:
     The function/method writes the specified image to video file. It must have the same size as has
     been specified when opening the video writer.
      */
+#if CV_MAJOR_VERSION >= 5
+    virtual bool write(cv::InputArray image);
+#else
     virtual void write(cv::InputArray image);
-
+#endif
     /** @brief Sets a property in the VideoWriter.
 
      @param propId Property identifier from cv::VideoWriterProperties (eg. cv::VIDEOWRITER_PROP_QUALITY)

--- a/sdk/modules/core/cpp/src/3rdparty/container_avi.cpp
+++ b/sdk/modules/core/cpp/src/3rdparty/container_avi.cpp
@@ -22,9 +22,17 @@ inline D safe_int_cast(S val, const char * msg = 0)
     if (!in_range_r || !in_range_l)
     {
         if (!msg)
+#if CV_MAJOR_VERSION >= 5
+            error(Exception(Error::StsOutOfRange, format("Can not convert integer values (%s -> %s), value 0x%jx is out of range", typeid(S).name(), typeid(D).name(), (uintmax_t)val), __func__, __FILE__, __LINE__));
+#else
             CV_Error_(Error::StsOutOfRange, ("Can not convert integer values (%s -> %s), value 0x%jx is out of range", typeid(S).name(), typeid(D).name(), (uintmax_t)val));
+#endif
         else
+#if CV_MAJOR_VERSION >= 5
+            error(Exception(Error::StsOutOfRange, msg, __func__, __FILE__, __LINE__));
+#else
             CV_Error(Error::StsOutOfRange, msg);
+#endif
     }
     return static_cast<D>(val);
 }

--- a/sdk/modules/core/cpp/src/utils/video_writer.cpp
+++ b/sdk/modules/core/cpp/src/utils/video_writer.cpp
@@ -51,7 +51,11 @@
 //M*/
 
 #include <opencv2/videoio.hpp>
+#if CV_MAJOR_VERSION < 4
 #include <opencv2/core/types_c.h>
+#elif CV_MAJOR_VERSION < 5
+#include <opencv2/imgproc/types_c.h>
+#endif
 
 #include "metavision/sdk/base/utils/sdk_log.h"
 #include "metavision/sdk/core/utils/video_writer.h"
@@ -94,11 +98,20 @@ using ParallelLoopBody = ::cv::ParallelLoopBody;
 using Range            = ::cv::Range;
 
 namespace Error {
+#if CV_MAJOR_VERSION >= 5
+using Code = ::cv::Error::Code;
+constexpr Code StsAssert       = ::cv::Error::StsAssert;
+constexpr Code StsOutOfRange   = ::cv::Error::StsOutOfRange;
+constexpr Code StsVecLengthErr = ::cv::Error::StsVecLengthErr;
+constexpr Code StsBadArg       = ::cv::Error::StsBadArg;
+#else
 enum Code {
     StsAssert       = ::cv::Error::StsAssert,
     StsOutOfRange   = ::cv::Error::StsOutOfRange,
-    StsVecLengthErr = ::cv::Error::StsVecLengthErr
+    StsVecLengthErr = ::cv::Error::StsVecLengthErr,
+    StsBadArg       = ::cv::Error::StsBadArg
 };
+#endif
 }
 
 using ::cv::error;
@@ -209,6 +222,15 @@ enum VideoWriterProperties {
 
 // including OpenCV's implementation from v4.5.0
 #define cv cv45 // not super clean, but it's the easiest way to get the job done
+#ifndef CV_StsBadArg
+#define CV_StsBadArg cv45::Error::StsBadArg
+#endif
+#ifndef CV_StsOutOfRange
+#define CV_StsOutOfRange cv45::Error::StsOutOfRange
+#endif
+#ifndef CV_StsAssert
+#define CV_StsAssert cv45::Error::StsAssert
+#endif
 #include "3rdparty/container_avi.cpp"
 #include "3rdparty/cap_mjpeg_encoder.cpp"
 #undef cv
@@ -343,6 +365,16 @@ cv::String VideoWriter::getBackendName() const {
 #endif
 }
 
+#if CV_MAJOR_VERSION >= 5
+bool VideoWriter::write(cv::InputArray image) {
+    if (writer_) {
+        writer_->write(image);
+        return true;
+    }
+    cv::VideoWriter::write(image);
+    return true;
+}
+#else
 void VideoWriter::write(cv::InputArray image) {
     if (writer_) {
         writer_->write(image);
@@ -354,6 +386,7 @@ void VideoWriter::write(cv::InputArray image) {
     cv::VideoWriter::write(image);
 #endif
 }
+#endif
 
 VideoWriter &VideoWriter::operator<<(const cv::Mat &image) {
     if (writer_) {

--- a/sdk/modules/stream/cpp/samples/metavision_active_pixel_detection/metavision_active_pixel_detection.cpp
+++ b/sdk/modules/stream/cpp/samples/metavision_active_pixel_detection/metavision_active_pixel_detection.cpp
@@ -19,7 +19,7 @@
 #include <thread>
 #include <boost/program_options.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#if CV_MAJOR_VERSION >= 4
+#if CV_MAJOR_VERSION >= 4 && CV_MAJOR_VERSION < 5
 #include <opencv2/highgui/highgui_c.h>
 #endif
 #include <opencv2/imgproc.hpp>

--- a/sdk/modules/stream/cpp/samples/metavision_viewer/metavision_viewer.cpp
+++ b/sdk/modules/stream/cpp/samples/metavision_viewer/metavision_viewer.cpp
@@ -19,7 +19,7 @@
 #include <thread>
 #include <boost/program_options.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#if CV_MAJOR_VERSION >= 4
+#if CV_MAJOR_VERSION >= 4 && CV_MAJOR_VERSION < 5
 #include <opencv2/highgui/highgui_c.h>
 #endif
 #include <opencv2/imgproc.hpp>
@@ -353,7 +353,11 @@ int main(int argc, char *argv[]) {
 
         // Setup CD frame display
         std::string cd_window_name("CD Events");
+#if CV_MAJOR_VERSION >= 5
+        cv::namedWindow(cd_window_name, cv::WINDOW_GUI_NORMAL);
+#else
         cv::namedWindow(cd_window_name, CV_GUI_NORMAL);
+#endif
         cv::resizeWindow(cd_window_name, geometry.get_width(), geometry.get_height());
         cv::moveWindow(cd_window_name, 0, 0);
 #if (CV_MAJOR_VERSION == 3 && (CV_MINOR_VERSION * 100 + CV_SUBMINOR_VERSION) >= 408) || \

--- a/sdk/modules/stream/cpp/src/hdf5_event_file_reader.cpp
+++ b/sdk/modules/stream/cpp/src/hdf5_event_file_reader.cpp
@@ -155,7 +155,11 @@ private:
         H5Dget_chunk_storage_size(dset_.getId(), offset, &compressed_size);
         if (decoding_cb_) {
             inbuf_.resize(compressed_size);
+#if (H5_VERS_MAJOR == 1 && H5_VERS_MINOR >= 13) || H5_VERS_MAJOR > 1
+            if (H5Dread_chunk(dset_.getId(), H5P_DEFAULT, offset, &filters, inbuf_.data(), nullptr) < 0) {
+#else
             if (H5Dread_chunk(dset_.getId(), H5P_DEFAULT, offset, &filters, inbuf_.data()) < 0) {
+#endif
                 return false;
             }
             // Make sure we have enough space to decode events, we will resize to correct size after decoding
@@ -164,7 +168,11 @@ private:
             events_.resize(std::min(num_bytes / sizeof(Metavision::EventCD), num_events_ - offset_));
         } else {
             events_.resize(std::min(chunk_size_, num_events_ - offset_));
+#if (H5_VERS_MAJOR == 1 && H5_VERS_MINOR >= 13) || H5_VERS_MAJOR > 1
+            if (H5Dread_chunk(dset_.getId(), H5P_DEFAULT, offset, &filters, events_.data(), nullptr) < 0) {
+#else
             if (H5Dread_chunk(dset_.getId(), H5P_DEFAULT, offset, &filters, events_.data()) < 0) {
+#endif
                 return false;
             }
         }
@@ -284,7 +292,11 @@ private:
         }
         hsize_t offset[1] = {offset_};
         std::uint32_t filters;
+#if (H5_VERS_MAJOR == 1 && H5_VERS_MINOR >= 13) || H5_VERS_MAJOR > 1
+        if (H5Dread_chunk(dset_.getId(), H5P_DEFAULT, offset, &filters, indexes_.data(), nullptr) < 0) {
+#else
         if (H5Dread_chunk(dset_.getId(), H5P_DEFAULT, offset, &filters, indexes_.data()) < 0) {
+#endif
             return false;
         }
         const size_t num_indexes = std::min(num_indexes_ - offset_, chunk_size_);


### PR DESCRIPTION
**HDF5 1.14 Support**: Added a macro guard to handle the updated 6-argument signature of H5Dread_chunk in HDF5 1.13/1.14+, preventing build failures on modern systems.